### PR TITLE
split warning fix

### DIFF
--- a/src/typeWriter.ts
+++ b/src/typeWriter.ts
@@ -16,7 +16,7 @@ export default class TypeWritter {
 
   public restartTypeWriter() {
     this.memoWord = this.nextWord
-    this.eventQueue = this.nextWord.split('')
+    this.eventQueue = this.nextWord
     this.erasing = false
     return ''
   }
@@ -27,7 +27,7 @@ export default class TypeWritter {
    *    |-- writing
    *    |-- erasing
    *    |-- restartWrite
-   * 
+   *
    * @returns
    * @memberof TypeWritter
    */

--- a/src/typeWriter.ts
+++ b/src/typeWriter.ts
@@ -16,7 +16,7 @@ export default class TypeWritter {
 
   public restartTypeWriter() {
     this.memoWord = this.nextWord
-    this.eventQueue = this.nextWord
+    this.eventQueue = this.nextWord ? this.nextWord.split('') : []
     this.erasing = false
     return ''
   }


### PR DESCRIPTION
Fixes split warning everytime the typewriter restarts after going through the entire array.

<img width="840" alt="Screen Shot 2019-08-15 at 6 31 37 PM" src="https://user-images.githubusercontent.com/10833686/63133492-0e225080-bf8b-11e9-9d96-1ed36ab2c10d.png">
